### PR TITLE
fixes and workaround for disabled stack guard warnings of hadoop libs

### DIFF
--- a/jobs/client/templates/bin/job_properties.sh.erb
+++ b/jobs/client/templates/bin/job_properties.sh.erb
@@ -6,9 +6,11 @@
 
 export SPARK_HOME=/var/vcap/packages/spark
 export MESOS_NATIVE_LIBRARY=/var/vcap/packages/mesos/lib/libmesos.so
-export SPARK_EXECUTOR_URI=hdfs://0.hdfs-master.default.mesos-ha-hdfs-aws.bosh/spark-0.9.1-hadoop_2.3.0-bin.tar.gz
+export SPARK_EXECUTOR_URI=hdfs://0.hdfs-master.default.mesos-ha-hdfs-aws.bosh/spark-0.9.1-hadoop_2.4.0-bin.tar.gz
 export HADOOP_HOME=/var/vcap/packages/hadoop
 export HADOOP_CONF_DIR=/var/vcap/jobs/client/config
+export HADOOP_COMMON_LIB_NATIVE_DIR={$HADOOP_HOME}/lib/native
+export HADOOP_OPTS="-Djava.library.path=$HADOOP_HOME/lib
 export SCALA_HOME=/var/vcap/packages/scala
 export JAVA_HOME=/var/vcap/packages/java/jdk
 export PATH=$JAVA_HOME/bin:$SPARK_HOME/bin:$SPARK_HOME/sbin:$SCALA_HOME/bin:$HADOOP_HOME/bin:/var/vcap/packages/git/bin:/var/vcap/packages/sbt/bin:/var/vcap/packages/pig/bin:/var/vcap/packages/hive/bin:$PATH


### PR DESCRIPTION
Looks like Hadoop compilation on JVM didn't use disabled stackguard. Using environment variable workaround to disable annoying warning when running hadoop commands
